### PR TITLE
Support touch events

### DIFF
--- a/examples/fit-to-area.html
+++ b/examples/fit-to-area.html
@@ -56,12 +56,12 @@
           minRatio: 1 / 1.5
         });
 
-        $('.icon-zoom-in').on('click touchstart', function(event) {
+        $('.icon-zoom-in').on('mouseup touchstart', function(event) {
           crop.zoomIn();
           event.stopPropagation();
         });
 
-        $('.icon-zoom-out').on('click touchstart', function(event) {
+        $('.icon-zoom-out').on('mouseup touchstart', function(event) {
           crop.zoomOut();
           event.stopPropagation();
         });

--- a/examples/fit-to-area.html
+++ b/examples/fit-to-area.html
@@ -56,12 +56,12 @@
           minRatio: 1 / 1.5
         });
 
-        $('.icon-zoom-in').on('click', function(event) {
+        $('.icon-zoom-in').on('click touchstart', function(event) {
           crop.zoomIn();
           event.stopPropagation();
         });
 
-        $('.icon-zoom-out').on('click', function(event) {
+        $('.icon-zoom-out').on('click touchstart', function(event) {
           crop.zoomOut();
           event.stopPropagation();
         });

--- a/examples/index.html
+++ b/examples/index.html
@@ -65,12 +65,12 @@
           height: 500
         })
 
-        $('.icon-zoom-in').on('click', function(event) {
+        $('.icon-zoom-in').on('click touchstart', function(event) {
           crop.zoomIn();
           event.stopPropagation();
         });
 
-        $('.icon-zoom-out').on('click', function(event) {
+        $('.icon-zoom-out').on('click touchstart', function(event) {
           crop.zoomOut();
           event.stopPropagation();
         });


### PR DESCRIPTION
## Motivation

Previously, the crop controls did only work for desktop devices, not for mobile, i.e. touch devices.
With this change, the cropping can also be performed from a mobile device.

## Changelog

- Introduce `touchstart`, `touchmove` and `touchend` events next to the equivalent mouse events (since we use namespaces on the events, it is necessary to explicitly declare the touch events)
- handle the calculation of `pageX` and `pageY` for both mobile and desktop cases